### PR TITLE
Fix computation of LUAJIT_INCLUDE_DIR

### DIFF
--- a/cmake/FindLuaJIT.cmake
+++ b/cmake/FindLuaJIT.cmake
@@ -31,7 +31,7 @@
 FIND_PATH(LUAJIT_INCLUDE_DIR lua.h
   HINTS
   $ENV{LUAJIT_DIR}
-  PATH_SUFFIXES include/luajit-2.0 include/luajit2.0 include/luajit include/luajit-2.1 include
+  PATH_SUFFIXES luajit-2.0 luajit2.0 luajit luajit-2.1
   PATHS
   ~/Library/Frameworks
   /Library/Frameworks


### PR DESCRIPTION
I don't think the current way cmake uses to locate the correct lua.h
works.  Entries like "include/foo.h" cause cmake to look for a file
like "/usr/include/include/foo.h".  I.e., the include/ prefix for
all the entries is wrong as is adding "include" at the end.

This patch removes the prefix.  With it bcc finally compiles on
Fedora.

If this change causes a problem there is something seriously wrong
with cmake.